### PR TITLE
Add board state, allow toggling of swimlanes

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { BytesizePipe } from './pipes/bytesize.pipe';
 import { ObscurePipe } from './pipes/obscure.pipe';
 import { PivotalAPIService } from './pivotal-api.service';
 import { MeService } from './resources/me.service';
+import { BoardQuery, BoardStore, BoardService } from './store/board';
 import { EpicQuery, EpicStore, EpicService } from './store/epic';
 import { ProjectQuery, ProjectStore, ProjectService } from './store/project';
 import { StoryQuery, StoryStore, StoryService } from './store/story';
@@ -84,6 +85,9 @@ import { StoryQuery, StoryStore, StoryService } from './store/story';
     StoryService,
     StoryQuery,
     StoryStore,
+    BoardQuery,
+    BoardStore,
+    BoardService,
     PeopleStoreService,
     {
       provide: LocalStorageService,

--- a/src/app/containers/project-board/project-board.component.html
+++ b/src/app/containers/project-board/project-board.component.html
@@ -1,74 +1,100 @@
-<section class="viewport px-3">
+<section class="viewport px-3 pt-3">
+  <div class="container-fluid py-2">
+    <div
+      class="border border-muted rounded px-3 py-2"
+      role="group"
+      *ngIf="inactiveStateKeys.length"
+    >
+      <span class="mr-3">Hidden:</span>
+      <button
+        class="btn btn-secondary btn-sm mr-2"
+        type="button"
+        *ngFor="let inactiveState of inactiveStateKeys"
+        (click)="toggleSwimlane(inactiveState)"
+      >
+        {{ inactiveState }}
+        <i class="fas fa-times"></i>
+      </button>
+    </div>
+  </div>
   <section
-    class="pool mt-4 mb-5 py-2"
+    class="pool mb-5 py-2"
     [style.width.rem]="(21 + 1) * displayOrder.length"
     *ngIf="!loading"
   >
-    <div class="swimlane mr-3" *ngFor="let stateName of displayOrder">
-      <header>
-        <h2 class="h4 d-inline mr-1">{{ stateName | titlecase }}</h2>
-        <span>({{ displayGroups[stateName]?.length || 0 }})</span>
-      </header>
-      <div class="y-scroll py-3">
-        <div *ngFor="let story of displayGroups[stateName]">
-          <button class="btn p-0 mb-3 w-100" (click)="openStoryModal(story)">
-            <article
-              class="card text-left"
-              [ngClass]="{
-                'alert-warning': story.story_type === 'feature',
-                'alert-danger': story.story_type === 'bug',
-                'alert-secondary': story.story_type === 'chore'
-              }"
-            >
-              <header class="card-body">
-                <h3 class="h5">{{ story.name }}</h3>
-              </header>
-              <div class="card-body pt-0">
-                <div class="d-flex flex-row">
-                  <span class="badge badge-light mr-1 mb-2">
-                    <i
-                      class="fas"
-                      [ngClass]="{
-                        'fa-star text-warning': story.story_type === 'feature',
-                        'fa-bug text-danger': story.story_type === 'bug',
-                        'fa-wrench text-secondary':
-                          story.story_type === 'chore',
-                        'fa-rocket text-secondary':
-                          story?.story_type === 'release'
-                      }"
-                    ></i>
-                    {{ story.story_type }}
-                  </span>
-                  <span class="badge badge-secondary mr-1 mb-2">{{
-                    story.requested_by?.name || '--'
-                  }}</span>
-                  <span class="badge badge-info mb-2">
-                    <i class="fas fa-signal"></i>
-                    {{ story.estimate || 'unestimated' }}
-                  </span>
+    <ng-container *ngFor="let stateName of displayOrder">
+      <div class="swimlane mr-3" *ngIf="boardState[stateName]">
+        <header class="d-flex align-items-center">
+          <div class="flex-grow-1">
+            <h2 class="h4 d-inline mr-1">{{ stateName | titlecase }}</h2>
+            <span>({{ displayGroups[stateName]?.length || 0 }})</span>
+          </div>
+          <div class="px-2">
+            <input type="checkbox" (change)="toggleSwimlane(stateName)" />
+          </div>
+        </header>
+        <div class="y-scroll py-3">
+          <div *ngFor="let story of displayGroups[stateName]">
+            <button class="btn p-0 mb-3 w-100" (click)="openStoryModal(story)">
+              <article
+                class="card text-left"
+                [ngClass]="{
+                  'alert-warning': story.story_type === 'feature',
+                  'alert-danger': story.story_type === 'bug',
+                  'alert-secondary': story.story_type === 'chore'
+                }"
+              >
+                <header class="card-body">
+                  <h3 class="h5">{{ story.name }}</h3>
+                </header>
+                <div class="card-body pt-0">
+                  <div class="d-flex flex-row">
+                    <span class="badge badge-light mr-1 mb-2">
+                      <i
+                        class="fas"
+                        [ngClass]="{
+                          'fa-star text-warning':
+                            story.story_type === 'feature',
+                          'fa-bug text-danger': story.story_type === 'bug',
+                          'fa-wrench text-secondary':
+                            story.story_type === 'chore',
+                          'fa-rocket text-secondary':
+                            story?.story_type === 'release'
+                        }"
+                      ></i>
+                      {{ story.story_type }}
+                    </span>
+                    <span class="badge badge-secondary mr-1 mb-2">{{
+                      story.requested_by?.name || '--'
+                    }}</span>
+                    <span class="badge badge-info mb-2">
+                      <i class="fas fa-signal"></i>
+                      {{ story.estimate || 'unestimated' }}
+                    </span>
+                  </div>
+                  <div class="d-flex flex-row flex-wrap">
+                    <span
+                      class="badge badge-dark badge-label mr-1 mb-2"
+                      [title]="label.name"
+                      *ngFor="let label of story.labels"
+                      >{{ label.name }}
+                    </span>
+                  </div>
+                  <div class="d-flex flex-row-reverse">
+                    <span
+                      class="badge badge-primary mt-2 mr-1"
+                      *ngFor="let owner of story.owners"
+                      [title]="owner?.name"
+                      >{{ owner?.initials | uppercase }}
+                    </span>
+                  </div>
                 </div>
-                <div class="d-flex flex-row flex-wrap">
-                  <span
-                    class="badge badge-dark badge-label mr-1 mb-2"
-                    [title]="label.name"
-                    *ngFor="let label of story.labels"
-                    >{{ label.name }}
-                  </span>
-                </div>
-                <div class="d-flex flex-row-reverse">
-                  <span
-                    class="badge badge-primary mt-2 mr-1"
-                    *ngFor="let owner of story.owners"
-                    [title]="owner?.name"
-                    >{{ owner?.initials | uppercase }}
-                  </span>
-                </div>
-              </div>
-            </article>
-          </button>
+              </article>
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </ng-container>
   </section>
 </section>
 

--- a/src/app/local-storage.service.ts
+++ b/src/app/local-storage.service.ts
@@ -20,7 +20,33 @@ export class LocalStorageService {
     return localStorage.getItem(`${this.prefix}${key}`);
   }
 
-  set(key: string, value: string): void {
+  set(key: string, value: any): void {
     localStorage.setItem(`${this.prefix}${key}`, value);
+  }
+
+  add(key: string, value: string): void {
+    const item: string = localStorage.getItem(`${this.prefix}${key}`);
+
+    if (item) {
+      const list: string[] = item.split(',');
+      list.push(value);
+      localStorage.setItem(`${this.prefix}${key}`, list.toString());
+    } else {
+      localStorage.setItem(`${this.prefix}${key}`, value);
+    }
+  }
+
+  remove(key: string, value: string): void {
+    const item: string = localStorage.getItem(`${this.prefix}${key}`);
+
+    if (item) {
+      const list: string[] = item.split(',');
+
+      const index = list.indexOf(value);
+      if (index > -1) {
+        list.splice(index, 1);
+      }
+      localStorage.setItem(`${this.prefix}${key}`, list.toString());
+    }
   }
 }

--- a/src/app/store/board/board.query.ts
+++ b/src/app/store/board/board.query.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { Query } from '@datorama/akita';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { BoardStore, BoardState } from './board.store';
+
+@Injectable({ providedIn: 'root' })
+export class BoardQuery extends Query<BoardState> {
+  activeStateKeys$: Observable<string[]> = this.select('stateSwimlane').pipe(
+    map(states =>
+      Object.entries(states)
+        .filter(([, value]) => value)
+        .map(([key]) => key)
+    )
+  );
+
+  inactiveStateKeys$: Observable<string[]> = this.select('stateSwimlane').pipe(
+    map(states =>
+      Object.entries(states)
+        .filter(([, value]) => !value)
+        .map(([key]) => key)
+        .filter(key => !!key)
+    )
+  );
+
+  constructor(protected store: BoardStore) {
+    super(store);
+  }
+}

--- a/src/app/store/board/board.service.ts
+++ b/src/app/store/board/board.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+
+import { LocalStorageService } from '@app/local-storage.service';
+
+import { StoryStateName } from '../story';
+import { BoardStore, BoardState } from './board.store';
+
+@Injectable({ providedIn: 'root' })
+export class BoardService {
+  constructor(
+    private boardStore: BoardStore,
+    private localStorage: LocalStorageService
+  ) {}
+
+  toggleSwimlane(stateName: StoryStateName): boolean {
+    let newSwimlaneState: boolean;
+    this.boardStore.update(state => {
+      newSwimlaneState = !state.stateSwimlane[stateName];
+
+      const newState: BoardState = {
+        ...state,
+        stateSwimlane: {
+          ...state.stateSwimlane,
+          [stateName]: newSwimlaneState,
+        },
+      };
+
+      if (newSwimlaneState) {
+        this.localStorage.remove('hideStates', stateName);
+      } else {
+        this.localStorage.add('hideStates', stateName);
+      }
+
+      return newState;
+    });
+    return newSwimlaneState;
+  }
+}

--- a/src/app/store/board/board.store.ts
+++ b/src/app/store/board/board.store.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { Store, StoreConfig } from '@datorama/akita';
+
+import { LocalStorageService } from '@app/local-storage.service';
+
+import { StoryStateName } from '../story';
+
+export interface BoardState {
+  stateSwimlane: {
+    [key in StoryStateName]: boolean;
+  };
+}
+
+export const createInitialState = (): BoardState => {
+  return {
+    stateSwimlane: {
+      planned: true,
+      unscheduled: true,
+      unstarted: true,
+      started: true,
+      finished: true,
+      delivered: true,
+      accepted: true,
+    },
+  };
+};
+
+@Injectable({ providedIn: 'root' })
+@StoreConfig({ name: 'board' })
+export class BoardStore extends Store<BoardState> {
+  constructor(private localStorage: LocalStorageService) {
+    super(createInitialState());
+    this.initBoardStatesFromLocalStorage();
+  }
+
+  private initBoardStatesFromLocalStorage(): void {
+    // Get a list of states to hide
+    const boardState = this.localStorage.get('hideStates') || '';
+
+    // Set each state in storage to "false"
+    boardState.split(',').forEach((stateName: StoryStateName) => {
+      this.update(state => ({
+        ...state,
+        stateSwimlane: { ...state.stateSwimlane, [stateName]: false },
+      }));
+    });
+  }
+}

--- a/src/app/store/board/index.ts
+++ b/src/app/store/board/index.ts
@@ -1,0 +1,3 @@
+export * from './board.query';
+export * from './board.store';
+export * from './board.service';


### PR DESCRIPTION
## Description
Add functionality to toggle display of swimlanes in board view.

 - add `Board` store to hold board UI state
 - store and retrieve swimlane display in localStorage for persistence

![board_state_toggle](https://user-images.githubusercontent.com/3165644/74129712-1c95a180-4b95-11ea-8b7f-1bc7965b07f1.gif)
